### PR TITLE
Add bulk break planning and streamlined employee setup

### DIFF
--- a/app/Http/Controllers/BreakController.php
+++ b/app/Http/Controllers/BreakController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Shift;
 use App\Models\BusyPeriod;
+use Illuminate\Http\Request;
 
 class BreakController extends Controller
 {
@@ -18,24 +19,57 @@ class BreakController extends Controller
         $next = null;
         if (!$busy) {
             $next = $shifts->first(function ($shift) {
-                return $shift->breakPeriods()->where('status', 'confirmed')->doesntExist();
+                return $shift->remainingBreakMinutes() > 0;
             });
         }
 
         return view('breaks.index', compact('shifts', 'next', 'busy'));
     }
 
-    public function confirm(Shift $shift)
+    public function confirm(Request $request, Shift $shift)
     {
         if (BusyPeriod::current()) {
             return back()->withErrors('Druk moment: geen pauze mogelijk.');
         }
 
+        $minutes = (int) $request->input('minutes', $shift->nextBreakSuggestion());
+        $minutes = min($minutes, $shift->remainingBreakMinutes());
+        if ($minutes <= 0) {
+            return back();
+        }
+
         $shift->breakPeriods()->create([
             'start_time' => now(),
-            'end_time' => now()->addMinutes($shift->breakMinutes()),
+            'end_time' => now()->addMinutes($minutes),
             'status' => 'confirmed',
         ]);
+
+        return back();
+    }
+
+    public function bulkConfirm(Request $request)
+    {
+        if (BusyPeriod::current()) {
+            return back()->withErrors('Druk moment: geen pauze mogelijk.');
+        }
+
+        $data = $request->validate([
+            'shift_ids' => 'required|array',
+            'shift_ids.*' => 'exists:shifts,id',
+            'minutes' => 'required|integer|min:1',
+        ]);
+
+        foreach ($data['shift_ids'] as $id) {
+            $shift = Shift::find($id);
+            $minutes = min($data['minutes'], $shift->remainingBreakMinutes());
+            if ($minutes > 0) {
+                $shift->breakPeriods()->create([
+                    'start_time' => now(),
+                    'end_time' => now()->addMinutes($minutes),
+                    'status' => 'confirmed',
+                ]);
+            }
+        }
 
         return back();
     }

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\Employee;
+use App\Models\Shift;
+use App\Models\BreakPeriod;
 use Illuminate\Http\Request;
 
 class EmployeeController extends Controller
@@ -22,8 +24,14 @@ class EmployeeController extends Controller
     {
         $data = $request->validate([
             'name' => 'required|string|max:255',
+            'start_time' => 'required|date',
+            'end_time' => 'required|date|after:start_time',
         ]);
-        Employee::create($data);
+        $employee = Employee::create(['name' => $data['name']]);
+        $employee->shifts()->create([
+            'start_time' => $data['start_time'],
+            'end_time' => $data['end_time'],
+        ]);
         return redirect()->route('employees.index');
     }
 
@@ -36,6 +44,14 @@ class EmployeeController extends Controller
     public function destroy(Employee $employee)
     {
         $employee->delete();
+        return redirect()->route('employees.index');
+    }
+
+    public function destroyAll()
+    {
+        BreakPeriod::truncate();
+        Shift::truncate();
+        Employee::truncate();
         return redirect()->route('employees.index');
     }
 }

--- a/app/Models/Shift.php
+++ b/app/Models/Shift.php
@@ -38,4 +38,28 @@ class Shift extends Model
         $rule = BreakRule::forHours($hours);
         return $rule?->break_minutes ?? 0;
     }
+
+    public function takenBreakMinutes(): int
+    {
+        return $this->breakPeriods
+            ->where('status', 'confirmed')
+            ->sum(fn($period) => $period->duration);
+    }
+
+    public function remainingBreakMinutes(): int
+    {
+        return max(0, $this->breakMinutes() - $this->takenBreakMinutes());
+    }
+
+    public function nextBreakSuggestion(): int
+    {
+        $remaining = $this->remainingBreakMinutes();
+        if ($remaining > 30) {
+            return 30;
+        }
+        if ($remaining > 15) {
+            return 15;
+        }
+        return $remaining;
+    }
 }

--- a/resources/views/breaks/index.blade.php
+++ b/resources/views/breaks/index.blade.php
@@ -9,10 +9,16 @@
         @elseif($next)
             <div class="mb-4 p-4 bg-green-100">Volgende pauze: {{ $next->employee->name }}</div>
         @endif
+        <form id="bulk-break-form" method="POST" action="{{ route('breaks.bulk-confirm') }}" class="mb-4">
+            @csrf
+            <input type="number" name="minutes" value="30" class="border p-1 w-20 mr-2" min="1">
+            <button class="bg-green-500 text-white px-4 py-2 rounded">Start geselecteerde pauzes</button>
+        </form>
 
         <table class="min-w-full bg-white">
             <thead>
                 <tr class="border-b">
+                    <th class="p-2"></th>
                     <th class="p-2 text-left">Medewerker</th>
                     <th class="p-2 text-left">Shift</th>
                     <th class="p-2 text-left">Pauzes</th>
@@ -22,6 +28,7 @@
             <tbody>
                 @foreach($shifts as $shift)
                     <tr class="border-b align-top">
+                        <td class="p-2"><input type="checkbox" name="shift_ids[]" value="{{ $shift->id }}" form="bulk-break-form"></td>
                         <td class="p-2"><a href="{{ route('employees.show', $shift->employee) }}" class="text-blue-600">{{ $shift->employee->name }}</a></td>
                         <td class="p-2">{{ $shift->start_time }} - {{ $shift->end_time }}</td>
                         <td class="p-2">
@@ -29,11 +36,8 @@
                                 <div>{{ $period->start_time }} - {{ $period->end_time }} ({{ $period->duration }} min, {{ $period->status }})</div>
                             @endforeach
                         </td>
-                        <td class="p-2 space-x-2">
-                            <form method="POST" action="{{ route('breaks.confirm', $shift) }}" class="inline">
-                                @csrf
-                                <button class="text-green-600">Start pauze</button>
-                            </form>
+                        <td class="p-2 space-y-2">
+                            <div>Aanbevolen: {{ $shift->nextBreakSuggestion() }} min (resterend: {{ $shift->remainingBreakMinutes() }} min)</div>
                             <form method="POST" action="{{ route('breaks.reject', $shift) }}" class="inline">
                                 @csrf
                                 <button class="text-red-600">Weiger</button>

--- a/resources/views/employees/create.blade.php
+++ b/resources/views/employees/create.blade.php
@@ -10,6 +10,16 @@
             <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" required />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
+        <div>
+            <x-input-label for="start_time" :value="__('Shift starttijd')" />
+            <x-text-input id="start_time" name="start_time" type="datetime-local" class="mt-1 block w-full" required />
+            <x-input-error :messages="$errors->get('start_time')" class="mt-2" />
+        </div>
+        <div>
+            <x-input-label for="end_time" :value="__('Shift eindtijd')" />
+            <x-text-input id="end_time" name="end_time" type="datetime-local" class="mt-1 block w-full" required />
+            <x-input-error :messages="$errors->get('end_time')" class="mt-2" />
+        </div>
 
         <x-primary-button>{{ __('Opslaan') }}</x-primary-button>
     </form>

--- a/resources/views/employees/index.blade.php
+++ b/resources/views/employees/index.blade.php
@@ -4,8 +4,13 @@
     </x-slot>
 
     <div class="py-6">
-        <div class="mb-4">
+        <div class="mb-4 space-x-2">
             <a href="{{ route('employees.create') }}" class="bg-blue-500 text-white px-4 py-2 rounded">Nieuwe medewerker</a>
+            <form method="POST" action="{{ route('employees.destroyAll') }}" class="inline">
+                @csrf
+                @method('DELETE')
+                <button class="bg-red-500 text-white px-4 py-2 rounded">Verwijder alle</button>
+            </form>
         </div>
 
         <ul class="bg-white shadow divide-y">

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,11 +21,13 @@ Route::middleware('auth')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
+    Route::delete('employees', [EmployeeController::class, 'destroyAll'])->name('employees.destroyAll');
     Route::resource('employees', EmployeeController::class);
     Route::resource('shifts', ShiftController::class);
     Route::resource('break-rules', BreakRuleController::class)->only(['index', 'edit', 'update']);
     Route::resource('busy-periods', BusyPeriodController::class)->only(['index', 'store', 'destroy']);
     Route::get('breaks', [BreakController::class, 'index'])->name('breaks.index');
+    Route::post('breaks/bulk-confirm', [BreakController::class, 'bulkConfirm'])->name('breaks.bulk-confirm');
     Route::post('breaks/{shift}/confirm', [BreakController::class, 'confirm'])->name('breaks.confirm');
     Route::post('breaks/{shift}/reject', [BreakController::class, 'reject'])->name('breaks.reject');
 });


### PR DESCRIPTION
## Summary
- Add shift fields when creating an employee and support clearing all employees
- Track remaining break time with 15/30 minute suggestions and bulk break start
- Show recommended and remaining break time in planner with multi-selection

## Testing
- `composer install`
- `npm run build`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68b98d3fc5c88323a68fb81d52ee4561