### PR TITLE
Add break rule management and sidebar layout

### DIFF
--- a/app/Http/Controllers/BreakRuleController.php
+++ b/app/Http/Controllers/BreakRuleController.php
@@ -13,6 +13,11 @@ class BreakRuleController extends Controller
         return view('break_rules.index', compact('rules'));
     }
 
+    public function create()
+    {
+        return view('break_rules.create');
+    }
+
     public function edit(BreakRule $break_rule)
     {
         return view('break_rules.edit', compact('break_rule'));
@@ -26,6 +31,23 @@ class BreakRuleController extends Controller
             'break_minutes' => 'required|integer',
         ]);
         $break_rule->update($data);
+        return redirect()->route('break-rules.index');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'min_hours' => 'required|numeric',
+            'max_hours' => 'nullable|numeric',
+            'break_minutes' => 'required|integer',
+        ]);
+        BreakRule::create($data);
+        return redirect()->route('break-rules.index');
+    }
+
+    public function destroy(BreakRule $break_rule)
+    {
+        $break_rule->delete();
         return redirect()->route('break-rules.index');
     }
 }

--- a/resources/views/break_rules/create.blade.php
+++ b/resources/views/break_rules/create.blade.php
@@ -1,0 +1,23 @@
+<x-app-layout>
+    <x-slot name="header">
+        {{ __('Nieuwe pauzeregel') }}
+    </x-slot>
+
+    <form method="POST" action="{{ route('break-rules.store') }}" class="p-6 max-w-md space-y-4">
+        @csrf
+        <div>
+            <x-input-label for="min_hours" :value="__('Min uren')" />
+            <x-text-input id="min_hours" name="min_hours" type="number" step="0.1" class="mt-1 block w-full" required />
+        </div>
+        <div>
+            <x-input-label for="max_hours" :value="__('Max uren')" />
+            <x-text-input id="max_hours" name="max_hours" type="number" step="0.1" class="mt-1 block w-full" />
+        </div>
+        <div>
+            <x-input-label for="break_minutes" :value="__('Pauze (minuten)')" />
+            <x-text-input id="break_minutes" name="break_minutes" type="number" class="mt-1 block w-full" required />
+        </div>
+
+        <x-primary-button>{{ __('Opslaan') }}</x-primary-button>
+    </form>
+</x-app-layout>

--- a/resources/views/break_rules/index.blade.php
+++ b/resources/views/break_rules/index.blade.php
@@ -4,13 +4,16 @@
     </x-slot>
 
     <div class="py-6">
+        <div class="mb-4">
+            <a href="{{ route('break-rules.create') }}" class="bg-blue-500 text-white px-4 py-2 rounded">Nieuwe regel</a>
+        </div>
         <table class="min-w-full bg-white">
             <thead>
                 <tr class="border-b">
                     <th class="p-2 text-left">Min uren</th>
                     <th class="p-2 text-left">Max uren</th>
                     <th class="p-2 text-left">Pauze (minuten)</th>
-                    <th></th>
+                    <th class="p-2 text-left">Acties</th>
                 </tr>
             </thead>
             <tbody>
@@ -19,7 +22,14 @@
                         <td class="p-2">{{ $rule->min_hours }}</td>
                         <td class="p-2">{{ $rule->max_hours ?? '∞' }}</td>
                         <td class="p-2">{{ $rule->break_minutes }}</td>
-                        <td class="p-2"><a href="{{ route('break-rules.edit', $rule) }}" class="text-blue-600">Wijzig</a></td>
+                        <td class="p-2 space-x-2">
+                            <a href="{{ route('break-rules.edit', $rule) }}" class="text-blue-600">Wijzig</a>
+                            <form method="POST" action="{{ route('break-rules.destroy', $rule) }}" class="inline">
+                                @csrf
+                                @method('DELETE')
+                                <button class="text-red-600">Verwijder</button>
+                            </form>
+                        </td>
                     </tr>
                 @endforeach
             </tbody>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,23 +14,25 @@
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
-    <body class="font-sans antialiased">
-        <div class="min-h-screen bg-gray-100">
-            @include('layouts.navigation')
-
-            <!-- Page Heading -->
-            @isset($header)
-                <header class="bg-white shadow">
-                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                        {{ $header }}
-                    </div>
+    <body class="font-sans antialiased" x-data="{ open: false }">
+        <div class="min-h-screen bg-gray-100 flex">
+            <div :class="{'block': open, 'hidden': !open}" class="fixed inset-0 bg-black bg-opacity-25 sm:hidden" @click="open=false"></div>
+            <nav :class="{'-translate-x-full': !open}" class="fixed z-30 w-64 bg-white h-full border-r transform transition-transform duration-150 ease-in-out sm:translate-x-0">
+                @include('layouts.navigation')
+            </nav>
+            <div class="flex-1 flex flex-col sm:ml-64">
+                <header class="bg-white shadow flex items-center justify-between p-4 sm:justify-end">
+                    <button @click="open = !open" class="sm:hidden text-gray-700 focus:outline-none">
+                        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+                    </button>
+                    @isset($header)
+                        <div class="text-gray-800 text-lg">{{ $header }}</div>
+                    @endisset
                 </header>
-            @endisset
-
-            <!-- Page Content -->
-            <main>
-                {{ $slot }}
-            </main>
+                <main class="p-4">
+                    {{ $slot }}
+                </main>
+            </div>
         </div>
     </body>
 </html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,100 +1,15 @@
-<nav x-data="{ open: false }" class="bg-white border-b border-gray-100">
-    <!-- Primary Navigation Menu -->
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
-            <div class="flex">
-                <!-- Logo -->
-                <div class="shrink-0 flex items-center">
-                    <a href="{{ route('dashboard') }}">
-                        <x-application-logo class="block h-9 w-auto fill-current text-gray-800" />
-                    </a>
-                </div>
-
-                <!-- Navigation Links -->
-                <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                        {{ __('Dashboard') }}
-                    </x-nav-link>
-                </div>
-            </div>
-
-            <!-- Settings Dropdown -->
-            <div class="hidden sm:flex sm:items-center sm:ms-6">
-                <x-dropdown align="right" width="48">
-                    <x-slot name="trigger">
-                        <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
-                            <div>{{ Auth::user()->name }}</div>
-
-                            <div class="ms-1">
-                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                </svg>
-                            </div>
-                        </button>
-                    </x-slot>
-
-                    <x-slot name="content">
-                        <x-dropdown-link :href="route('profile.edit')">
-                            {{ __('Profile') }}
-                        </x-dropdown-link>
-
-                        <!-- Authentication -->
-                        <form method="POST" action="{{ route('logout') }}">
-                            @csrf
-
-                            <x-dropdown-link :href="route('logout')"
-                                    onclick="event.preventDefault();
-                                                this.closest('form').submit();">
-                                {{ __('Log Out') }}
-                            </x-dropdown-link>
-                        </form>
-                    </x-slot>
-                </x-dropdown>
-            </div>
-
-            <!-- Hamburger -->
-            <div class="-me-2 flex items-center sm:hidden">
-                <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
-                    <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                        <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
-            </div>
-        </div>
+<div class="h-full flex flex-col p-4 space-y-2">
+    <a href="{{ route('dashboard') }}" class="font-bold text-xl mb-4 text-gray-800">Pauze Tracker</a>
+    <a href="{{ route('dashboard') }}" class="px-2 py-1 rounded hover:bg-gray-100 text-gray-700">Dashboard</a>
+    <a href="{{ route('employees.index') }}" class="px-2 py-1 rounded hover:bg-gray-100 text-gray-700">Medewerkers</a>
+    <a href="{{ route('shifts.index') }}" class="px-2 py-1 rounded hover:bg-gray-100 text-gray-700">Shifts</a>
+    <a href="{{ route('breaks.index') }}" class="px-2 py-1 rounded hover:bg-gray-100 text-gray-700">Pauzeplanner</a>
+    <a href="{{ route('break-rules.index') }}" class="px-2 py-1 rounded hover:bg-gray-100 text-gray-700">Pauzeregeling</a>
+    <a href="{{ route('busy-periods.index') }}" class="px-2 py-1 rounded hover:bg-gray-100 text-gray-700">Drukke momenten</a>
+    <div class="mt-auto">
+        <form method="POST" action="{{ route('logout') }}">
+            @csrf
+            <button class="px-2 py-1 rounded hover:bg-gray-100 text-gray-700 w-full text-left">Uitloggen</button>
+        </form>
     </div>
-
-    <!-- Responsive Navigation Menu -->
-    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
-        <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                {{ __('Dashboard') }}
-            </x-responsive-nav-link>
-        </div>
-
-        <!-- Responsive Settings Options -->
-        <div class="pt-4 pb-1 border-t border-gray-200">
-            <div class="px-4">
-                <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
-                <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
-            </div>
-
-            <div class="mt-3 space-y-1">
-                <x-responsive-nav-link :href="route('profile.edit')">
-                    {{ __('Profile') }}
-                </x-responsive-nav-link>
-
-                <!-- Authentication -->
-                <form method="POST" action="{{ route('logout') }}">
-                    @csrf
-
-                    <x-responsive-nav-link :href="route('logout')"
-                            onclick="event.preventDefault();
-                                        this.closest('form').submit();">
-                        {{ __('Log Out') }}
-                    </x-responsive-nav-link>
-                </form>
-            </div>
-        </div>
-    </div>
-</nav>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,7 @@ Route::middleware('auth')->group(function () {
     Route::delete('employees', [EmployeeController::class, 'destroyAll'])->name('employees.destroyAll');
     Route::resource('employees', EmployeeController::class);
     Route::resource('shifts', ShiftController::class);
-    Route::resource('break-rules', BreakRuleController::class)->only(['index', 'edit', 'update']);
+    Route::resource('break-rules', BreakRuleController::class)->except(['show']);
     Route::resource('busy-periods', BusyPeriodController::class)->only(['index', 'store', 'destroy']);
     Route::get('breaks', [BreakController::class, 'index'])->name('breaks.index');
     Route::post('breaks/bulk-confirm', [BreakController::class, 'bulkConfirm'])->name('breaks.bulk-confirm');


### PR DESCRIPTION
## Summary
- allow creating and deleting break rules
- move navigation into a sidebar with hamburger menu for mobile

## Testing
- `npm run build`
- `php artisan test` *(fails: database file at path database/database.sqlite does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b98fc907408323933f9718b8f0c7c2