### PR TITLE
Fix sidebar overlapping content

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -17,10 +17,10 @@
     <body class="font-sans antialiased" x-data="{ open: false }">
         <div class="min-h-screen bg-gray-100 flex">
             <div :class="{'block': open, 'hidden': !open}" class="fixed inset-0 bg-black bg-opacity-25 sm:hidden" @click="open=false"></div>
-            <nav :class="{'-translate-x-full': !open}" class="fixed z-30 w-64 bg-white h-full border-r transform transition-transform duration-150 ease-in-out sm:translate-x-0">
+            <nav :class="{'-translate-x-full': !open}" class="fixed sm:static z-30 w-64 bg-white h-full border-r transform transition-transform duration-150 ease-in-out sm:translate-x-0">
                 @include('layouts.navigation')
             </nav>
-            <div class="flex-1 flex flex-col sm:ml-64">
+            <div class="flex-1 flex flex-col">
                 <header class="bg-white shadow flex items-center justify-between p-4 sm:justify-end">
                     <button @click="open = !open" class="sm:hidden text-gray-700 focus:outline-none">
                         <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>


### PR DESCRIPTION
## Summary
- prevent sidebar from overlapping content by making it static on larger screens and removing offset margin

## Testing
- `php artisan test` (fails: Database file at path [...]/database.sqlite does not exist)

------
https://chatgpt.com/codex/tasks/task_e_68b9ca0b86008323a528c39c51b6512f