### PR TITLE
Improve sidebar layout with responsive hamburger menu

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -15,24 +15,27 @@
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
     <body class="font-sans antialiased" x-data="{ open: false }">
-        <div class="min-h-screen bg-gray-100 flex">
-            <div :class="{'block': open, 'hidden': !open}" class="fixed inset-0 bg-black bg-opacity-25 sm:hidden" @click="open=false"></div>
-            <nav :class="{'-translate-x-full': !open}" class="fixed sm:static z-30 w-64 bg-white h-full border-r transform transition-transform duration-150 ease-in-out sm:translate-x-0">
-                @include('layouts.navigation')
-            </nav>
-            <div class="flex-1 flex flex-col">
-                <header class="bg-white shadow flex items-center justify-between p-4 sm:justify-end">
-                    <button @click="open = !open" class="sm:hidden text-gray-700 focus:outline-none">
-                        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
-                    </button>
-                    @isset($header)
-                        <div class="text-gray-800 text-lg">{{ $header }}</div>
-                    @endisset
-                </header>
-                <main class="p-4">
-                    {{ $slot }}
-                </main>
-            </div>
+        <!-- Sidebar -->
+        <aside :class="{'-translate-x-full': !open}" class="fixed top-0 left-0 z-40 w-64 h-screen transform transition-transform bg-white border-r sm:translate-x-0" aria-label="Sidebar">
+            @include('layouts.navigation')
+        </aside>
+
+        <!-- Main content -->
+        <div class="min-h-screen bg-gray-100 sm:ml-64">
+            <header class="bg-white shadow flex items-center justify-between p-4 sm:justify-end">
+                <button @click="open = !open" class="sm:hidden text-gray-700 focus:outline-none">
+                    <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+                </button>
+                @isset($header)
+                    <div class="text-gray-800 text-lg">{{ $header }}</div>
+                @endisset
+            </header>
+            <main class="p-4">
+                {{ $slot }}
+            </main>
         </div>
+
+        <!-- Overlay -->
+        <div x-show="open" class="fixed inset-0 z-30 bg-black opacity-25 sm:hidden" @click="open = false"></div>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- Reworked layout markup to follow official responsive sidebar patterns
- Added hamburger toggle for mobile view and overlay when open
- Offset main content so sidebar no longer covers the UI

## Testing
- `npm run build`
- `vendor/bin/phpunit` *(fails: Database file at path [database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cb32b4a88323b8a30d6721ca5aba