### PR TITLE
Fix sidebar overlap and add mobile hamburger toggle

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -17,10 +17,10 @@
     <body class="font-sans antialiased" x-data="{ open: false }">
         <div class="min-h-screen bg-gray-100 flex">
             <div :class="{'block': open, 'hidden': !open}" class="fixed inset-0 bg-black bg-opacity-25 sm:hidden" @click="open=false"></div>
-            <nav :class="{'-translate-x-full': !open}" class="fixed sm:static z-30 w-64 bg-white h-full border-r transform transition-transform duration-150 ease-in-out sm:translate-x-0">
+            <nav :class="{'-translate-x-full': !open}" class="fixed inset-y-0 left-0 z-30 w-64 bg-white border-r transform transition-transform duration-150 ease-in-out sm:relative sm:translate-x-0 h-full">
                 @include('layouts.navigation')
             </nav>
-            <div class="flex-1 flex flex-col">
+            <div class="flex-1 flex flex-col sm:ml-64">
                 <header class="bg-white shadow flex items-center justify-between p-4 sm:justify-end">
                     <button @click="open = !open" class="sm:hidden text-gray-700 focus:outline-none">
                         <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>


### PR DESCRIPTION
## Summary
- Anchor sidebar to the viewport and prevent it from covering the main content
- Offset page content and enable hamburger toggle on small screens

## Testing
- `npm run build`
- `php artisan test` *(fails: Database file at path [/workspace/zakelijk-pauze-tracker-webapp/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cf9d854483239888edff6ea5c2fd